### PR TITLE
Set pixel in correct coordinate, even after scrolling page

### DIFF
--- a/src/components/PixelBoard.vue
+++ b/src/components/PixelBoard.vue
@@ -156,14 +156,14 @@ export default class PixelBoard extends Vue {
     }
   }
 
-  private addPixel(event: { clientX: number, clientY: number }) {
+  private addPixel(event: { pageX: number, pageY: number }) {
     if (this.loading) {
       return
     }
 
     this.selectedPixel = {
-      x: event.clientX - (event.clientX % 10),
-      y: event.clientY - (event.clientY % 10),
+      x: event.pageX - (event.pageX % 10),
+      y: event.pageY - (event.pageY % 10),
     }
 
     const pixels = this.pixels


### PR DESCRIPTION
Hey man, great work on this! I saw your comment in MPJ's video and decided to check this out. It looks and feels great to use!

I noticed that when you scroll down/right, the pixel would become out of sync with the users click coordinate. This PR fixes that little issue and should allow you to extend the size of the canvas, far beyond the size of a monitor screen.